### PR TITLE
Support for gzip compressed response

### DIFF
--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -228,7 +228,15 @@ CachedRequest.prototype.cachedRequest = function () {
           if (error) self.handleError(error);
         });
         responseWriter = fs.createWriteStream(self.cacheDirectory + key);
-        response.pipe(zlib.createGzip()).pipe(responseWriter);
+
+        var contentEncoding = response.headers['content-encoding'] || ''
+        contentEncoding = contentEncoding.trim().toLowerCase()
+
+        if (contentEncoding === 'gzip') {
+          response.pipe(responseWriter);
+        } else {
+          response.pipe(zlib.createGzip()).pipe(responseWriter);
+        }
       }
     });
     self.emit("request", args[0]);

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   },
   "devDependencies": {
     "chai": "^1.10.0",
-    "execSync": "^1.0.2",
     "mocha": "^2.1.0",
     "nock": "^0.52.4",
-    "request": "^2.51.0"
+    "request": "^2.51.0",
+    "temp": "^0.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js module to perform HTTP requests with caching support",
   "author": "Daniel López <danypype@gmail.com>",
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "main": "./lib/index.js",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 var CachedRequest = require("../")
 ,   request = require("request")
 ,   nock = require("nock")
-,   sh = require("execSync")
+,   temp = require('temp').track()
 ,   Readable = require("stream").Readable
 ,   util = require("util");
 
@@ -18,7 +18,7 @@ MockedResponseStream.prototype._read = function (size) {
 };
 
 describe("CachedRequest", function () {
-  var cacheDir = __dirname + "/cache";
+  var cacheDir;
 
   function mock (method, times, response) {
     method = method.toLowerCase();
@@ -31,12 +31,11 @@ describe("CachedRequest", function () {
   };
 
   before(function () {
-    sh.exec("mkdir " +  cacheDir);
     nock.disableNetConnect();
   });
 
   beforeEach(function () {
-    sh.exec("rm " +  cacheDir + "/*");
+    cacheDir = temp.mkdirSync("cache");
     this.cachedRequest = CachedRequest(request);
     this.cachedRequest.setCacheDirectory(cacheDir);
   });
@@ -130,6 +129,6 @@ describe("CachedRequest", function () {
   });
 
   after(function () {
-    sh.exec("rm -rf " +  cacheDir);
+    temp.cleanupSync();
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,8 @@ var CachedRequest = require("../")
 ,   nock = require("nock")
 ,   temp = require('temp').track()
 ,   Readable = require("stream").Readable
-,   util = require("util");
+,   util = require("util")
+,   zlib = require("zlib");
 
 util.inherits(MockedResponseStream, Readable);
 
@@ -20,14 +21,14 @@ MockedResponseStream.prototype._read = function (size) {
 describe("CachedRequest", function () {
   var cacheDir;
 
-  function mock (method, times, response) {
+  function mock (method, times, response, headers) {
     method = method.toLowerCase();
     times = times || 1;
     nock("http://ping.com")
       .filteringPath(/.+/, "/")
       [method]("/")
       .times(times)
-      .reply(200, response);
+      .reply(200, response, headers);
   };
 
   before(function () {
@@ -116,6 +117,49 @@ describe("CachedRequest", function () {
         .on("response", function (response) {
           expect(response.statusCode).to.equal(200);
           expect(response.headers["x-from-cache"]).to.equal(1);
+          response.on("data", function (data) {
+            body += data;
+          })
+          .on("end", function () {
+            expect(body).to.equal(responseBody);
+            done();
+          });
+        });
+      });
+    });
+
+    it("handles gzip response", function (done) {
+      var self = this;
+      var responseBody = "";
+
+      for (var i = 0; i < 1000; i++) {
+        responseBody += "this is a long response body";
+      };
+
+      //Return gzip compressed response with valid content encoding header
+      mock("GET", 1, function () {
+        return new MockedResponseStream({}, responseBody).pipe(zlib.createGzip());
+      }, 
+      {
+        "Content-Encoding": "gzip"
+      });
+
+      var options = {url: "http://ping.com/", ttl: 5000};
+      var body = "";
+
+      //Make fresh request
+      this.cachedRequest(options)
+      .on("data", function (data) {
+        //Ignore first reply
+      })
+      .on("end", function () {
+        body = "";
+        //Make cached request
+        self.cachedRequest(options)
+        .on("response", function (response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["x-from-cache"]).to.equal(1);
+          expect(response.headers["content-encoding"]).to.equal("gzip");
           response.on("data", function (data) {
             body += data;
           })


### PR DESCRIPTION
Do not compress the cached response if it was already gzip compressed.

Applicable when the `gzip: true` request option is used and the server has gzip support.

Use [temp](https://www.npmjs.org/package/temp) module for managing the temporary test cache dir.
