### PR TITLE
Gzip cached responses are not returned as original

### DIFF
--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -18,7 +18,7 @@ function Response (options) {
 };
 
 Response.prototype._transform = function (chunk, enconding, callback) {
-  this.push(chunk.toString());
+  this.push(chunk);
   callback();
 };
 
@@ -177,22 +177,28 @@ CachedRequest.prototype.cachedRequest = function () {
           //Emit the "response" event to the client sending the fake response
           requestMiddleware.emit("response", response);
 
-          //Gunzip the response file
-          gunzip = zlib.createGunzip();
-          responseReader.pipe(gunzip);
+          var stream;
+          if (response.headers['content-encoding'] === 'gzip') {
+            stream = responseReader;
+          } else {
+            // Gunzip the response file
+            stream = zlib.createGunzip();
+            responseReader.pipe(stream);
+          }
 
           //Read the response file
-          responseBody = "";
-          gunzip.on("data", function (data) {
-            data = data.toString();
+          var responseBody;
+          stream.on("data", function (data) {
             //Write to the response
             response.write(data);
             //If a callback was provided, then buffer the response to send it later
-            if (callback) responseBody += data;
+            if (callback) {
+              responseBody = responseBody ? Buffer.concat([responseBody, data]) : data;
+            }
             //Push data to the client's request
             requestMiddleware.push(data);
           });
-          gunzip.on("end", function () {
+          stream.on("end", function () {
             //End response
             response.end();
             //If a callback was provided
@@ -202,7 +208,7 @@ CachedRequest.prototype.cachedRequest = function () {
               //Parse the response body (it needed)
               if (mustParseJSON) {
                 try {
-                  responseBody = JSON.parse(responseBody);
+                  responseBody = JSON.parse(responseBody.toString());
                 } catch (e) {
                   return callback(e);
                 };

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,45 @@ describe("CachedRequest", function () {
         });
       });
     });
+
+    it("responds the same from the cache if gzipped", function (done) {
+      var self = this;
+      var responseBody = 'foo';
+      var options = {
+        url: "http://ping.com/",
+        ttl: 5000,
+        encoding: null // avoids messing with gzip responses so we can handle them
+      };
+
+      //Return gzip compressed response with valid content encoding header
+      mock("GET", 1, function () {
+        return new MockedResponseStream({}, responseBody).pipe(zlib.createGzip());
+      },
+      {
+        "Content-Encoding": "gzip"
+      });
+
+      this.cachedRequest(options, function (error, response, body) {
+        if (error) return done(error);
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers["x-from-cache"]).to.not.exist;
+        zlib.gunzip(body, function (error, buffer) {
+          if (error) return done(error);
+          expect(buffer.toString()).to.deep.equal(responseBody);
+
+          self.cachedRequest(options, function (error, response, body) {
+            if (error) return done(error);
+            expect(response.statusCode).to.equal(200);
+            expect(response.headers["x-from-cache"]).to.equal(1);
+            zlib.gunzip(body, function (error, buffer) {
+              if (error) done(error);
+              expect(buffer.toString()).to.deep.equal(responseBody);
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 
   describe("streaming", function () {


### PR DESCRIPTION
You will get a `Z_DATA_ERROR` when trying to gunzip a cached file that was returned originally as a gzip file.

Notice that the first request response, when gunzipped, will go through without issues.
