### PR TITLE
The default ttl value is now mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ When making a request, you must pass an `options` object as you can observe in t
       cachedRequest(options, callback);
     ```
 
+    You can also set a global ttl option for all requests:
+
+    ```javascript
+    cachedRequest.set('ttl', 1000);
+    cachedRequest({url: 'https://www.google.com'}, callback); // should benefit from the cache if previously cached
+    ```
+
 ##Can I use everything that comes with **request**?
 No, there's some things you can't use. For example, the shortcut functions `.get`, `.post`, `.put`, etc. are not available in **cached-request**. If you'd like to have them, this is a great opportunity to contribute!
 

--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -31,6 +31,7 @@ function CachedRequest (request) {
 
   this.request = request;
   this.cacheDirectory = "/tmp/";
+  this.ttl = 0;
 
   function _request () {
     return self.cachedRequest.apply(self, arguments);
@@ -103,7 +104,7 @@ CachedRequest.prototype.cachedRequest = function () {
   ,   requestMiddleware = new RequestMiddleware()
   ,   args = arguments
   ,   options = args[0]
-  ,   ttl = options.ttl || 0
+  ,   ttl = options.ttl || this.ttl
   ,   mustParseJSON = false
   ,   callback
   ,   headersReader


### PR DESCRIPTION
This allows to modify the default ttl used for all the requests, thus giving more control to set a different value as needed. In my case, I wanted to have a ttl gt 0 even if not provided by the requester for testing purposes.

```
cachedRequest.set('ttl', 1000);
cachedRequest({uri: 'http;//unicorn.com/resource.json'}, cb); // should benefit from the cache if previously cached
```
