### PR TITLE
Updating graceful-fs to >v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "caching"
   ],
   "dependencies": {
-    "graceful-fs": "^3.0.5"
+    "graceful-fs": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
- Upgraded package.json to take graceful-fs v4.0.0 or more. All the tests are passing

Reference issue :  #10 
