### PR TITLE
added gzipResponse option to enable/disable storing of responses as g…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool was made to work with the popular [request](https://github.com/request
 
 First, you instantiate a **cachedRequest** instance by passing a **request** function, which is going to act as the requester for the uncached requests - you still need to `$npm install request` independently. - Then, you can use **cachedRequest** to perform your HTTP requests.
 
-The caching takes place in the filesystem, storing the responses as compressed gzipped files.
+The caching takes place in the filesystem, storing the responses as compressed gzipped files by default.
 
 Please note this will cache *everything*, so don't use it for making things like POST or PUT requests that you don't want to be cached.
 
@@ -65,6 +65,16 @@ When making a request, you must pass an `options` object as you can observe in t
     ```javascript
     cachedRequest.setValue('ttl', 1000);
     cachedRequest({url: 'https://www.google.com'}, callback); // should benefit from the cache if previously cached
+    ```
+
+- `gzipResponse`: Flag to store responses as gzipped files on the filesystem. Default = true. Adds a `_gzipResponse` flag to the json headers file. 
+
+    ```javascript
+      var options = {
+        url: "https://www.google.com",
+        gzipResponse: false // downloaded files will not be gzipped when saved
+      };
+      cachedRequest(options, callback);
     ```
 
 ##Can I use everything that comes with **request**?

--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -10,7 +10,7 @@ var fs = require("graceful-fs")
 ,   zlib = require("zlib")
 ,   Transform = require("stream").Transform
 ,   EventEmitter = require("events").EventEmitter
-,   mkdirp = require('mkdirp');
+,   lo = require('lodash');
 
 util.inherits(Response, Transform);
 
@@ -33,6 +33,7 @@ function CachedRequest (request) {
   this.request = request;
   this.cacheDirectory = "/tmp/";
   this.ttl = 0;
+  this.gzipResponse = true;
 
   function _request () {
     return self.cachedRequest.apply(self, arguments);
@@ -70,8 +71,6 @@ CachedRequest.prototype.setCacheDirectory = function (cacheDirectory) {
   if (this.cacheDirectory.lastIndexOf("/") < this.cacheDirectory.length - 1) {
     this.cacheDirectory += "/";
   };
-  // Create directory path if it doesn't exist
-  mkdirp(this.cacheDirectory);
 };
 
 CachedRequest.prototype.handleError = function (error) {
@@ -114,6 +113,7 @@ CachedRequest.prototype.cachedRequest = function () {
   ,   args = arguments
   ,   options = args[0]
   ,   ttl = options.ttl || this.ttl
+  ,   gzipResponse = typeof(options.gzipResponse) === 'undefined' ? this.gzipResponse : options.gzipResponse
   ,   mustParseJSON = false
   ,   callback
   ,   headersReader
@@ -192,8 +192,10 @@ CachedRequest.prototype.cachedRequest = function () {
           //Emit the "response" event to the client sending the fake response
           requestMiddleware.emit("response", response);
 
+          var gzipResponse = response.headers._gzipResponse;
+
           var stream;
-          if (response.headers['content-encoding'] === 'gzip') {
+          if (response.headers['content-encoding'] === 'gzip' || ! gzipResponse) {
             stream = responseReader;
           } else {
             // Gunzip the response file
@@ -256,7 +258,12 @@ CachedRequest.prototype.cachedRequest = function () {
         response.on('error', function (error) {
           self.handleError(error);
         });
-        fs.writeFile(self.cacheDirectory + key + ".json", JSON.stringify(response.headers), function (error) {
+
+        // save metadata: response headers and gzipped flag
+        var meta = lo.clone(response.headers);
+        meta._gzipResponse = gzipResponse;
+
+        fs.writeFile(self.cacheDirectory + key + ".json", JSON.stringify(meta), function (error) {
           if (error) self.handleError(error);
         });
 
@@ -269,7 +276,7 @@ CachedRequest.prototype.cachedRequest = function () {
         contentEncoding = response.headers['content-encoding'] || '';
         contentEncoding = contentEncoding.trim().toLowerCase();
 
-        if (contentEncoding === 'gzip') {
+        if (contentEncoding === 'gzip' || ! gzipResponse) {
           response.on('error', function (error) {
             responseWriter.end();
           });

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   ],
   "dependencies": {
     "graceful-fs": "^4.0.0",
+    "lodash": "^4.15.0",
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "chai": "^1.10.0",
+    "mmmagic": "^0.4.5",
     "mocha": "^2.1.0",
     "nock": "^0.52.4",
     "request": "^2.51.0",


### PR DESCRIPTION
Hi thanks for this module, it's pretty nice.
I added a new option called `gzipResponse` which allows the user to disable the automatic gzipping of downloaded files.  It also stores an extra flag called `_gzipResponse` in each header file that indicates if the cached file itself is gzipped.
