### PR TITLE
Handling exception when parsing JSON file

### DIFF
--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -186,7 +186,14 @@ CachedRequest.prototype.cachedRequest = function () {
           response.headers += data.toString();
         });
         headersReader.on("end", function () {
-          response.headers = JSON.parse(response.headers);
+          try {
+            response.headers = JSON.parse(response.headers);
+          } catch (e) {
+            self.handleError(e);
+            headersReader.close();
+            return makeRequest();
+          }
+
           //Notify the response comes from the cache.
           response.headers["x-from-cache"] = 1;
           //Emit the "response" event to the client sending the fake response


### PR DESCRIPTION
These errors are causing frequent issues in my application.  I think the correct behavior is to pretend as if the cache entry was not found if it is corrupted.  

```
SyntaxError: Unexpected end of JSON input
    at Object.parse (native)
    at ReadStream.<anonymous> (/musicoin.org/node_modules/cached-request/lib/cached-request.js:189:35)
    at emitNone (events.js:91:20)
    at ReadStream.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

Also, another thing that should be done (I think) is use an atomic write pattern, where the newly cached output is written to `/some/file/name.json.tmp`, and then renamed to `/some/file/name.json` after a successful write.  If for whatever reason the write fails, there is no way a corrupted file can appear -- it's either there or it's not.

