### PR TITLE
Atomic write for cached header

### DIFF
--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -186,7 +186,14 @@ CachedRequest.prototype.cachedRequest = function () {
           response.headers += data.toString();
         });
         headersReader.on("end", function () {
-          response.headers = JSON.parse(response.headers);
+          try {
+            response.headers = JSON.parse(response.headers);
+          } catch (e) {
+            self.handleError(e);
+            headersReader.close();
+            return makeRequest();
+          }
+
           //Notify the response comes from the cache.
           response.headers["x-from-cache"] = 1;
           //Emit the "response" event to the client sending the fake response

--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -141,12 +141,13 @@ CachedRequest.prototype.cachedRequest = function () {
   key = this.hashKey(key);
 
   //Open headers file
-  headersReader = fs.createReadStream(this.cacheDirectory + key + ".json");
+  var cachedHeaderFileName = this.cacheDirectory + key + ".json";
+  headersReader = fs.createReadStream(cachedHeaderFileName);
 
   //If the file doesn't exist, then make the actual request
   headersReader.on("error", function (error) {
     if (error.code != "ENOENT") self.handleError(error);
-    makeRequest();
+    return makeRequest();
   });
 
   headersReader.on("open", function (fd) {
@@ -252,7 +253,7 @@ CachedRequest.prototype.cachedRequest = function () {
   });
 
   //Makes the actual request and caches the response
-  function makeRequest () {
+  function makeRequest() {
     request = self.request.apply(null, args);
     requestMiddleware.use(request);
     request.on("response", function (response) {
@@ -263,7 +264,12 @@ CachedRequest.prototype.cachedRequest = function () {
         response.on('error', function (error) {
           self.handleError(error);
         });
-        fs.writeFile(self.cacheDirectory + key + ".json", JSON.stringify(response.headers), function (error) {
+        var timestamp = Date.now();
+        var tmpHeaderName = cachedHeaderFileName + timestamp;
+
+        // Presence of the header means the cache entry is ready.  Save it to a temporary location
+        // until the caching process is complete.
+        fs.writeFile(tmpHeaderName, JSON.stringify(response.headers), function (error) {
           if (error) self.handleError(error);
         });
 
@@ -276,11 +282,12 @@ CachedRequest.prototype.cachedRequest = function () {
         contentEncoding = response.headers['content-encoding'] || '';
         contentEncoding = contentEncoding.trim().toLowerCase();
 
+        var stream;
         if (contentEncoding === 'gzip') {
           response.on('error', function (error) {
             responseWriter.end();
           });
-          response.pipe(responseWriter);
+          stream = response.pipe(responseWriter);
         } else {
           gzipper = zlib.createGzip();
           response.on('error', function (error) {
@@ -294,8 +301,16 @@ CachedRequest.prototype.cachedRequest = function () {
             response.unpipe(gzipper);
             gzipper.end();
           });
-          response.pipe(gzipper).pipe(responseWriter);
+          stream = response.pipe(gzipper).pipe(responseWriter);
         }
+
+        // once the stream is complete, we know the data file was written succesfully
+        // after that, it's ok to rename the header file so future requests can use it.
+        stream.on('finish', function(){
+          fs.rename(tmpHeaderName, cachedHeaderFileName, function(err) {
+            if (err) self.handleError(err);
+          })
+        });;
       }
     });
     self.emit("request", args[0]);

--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -145,12 +145,13 @@ CachedRequest.prototype.cachedRequest = function () {
   key = this.hashKey(key);
 
   //Open headers file
-  headersReader = fs.createReadStream(this.cacheDirectory + key + ".json");
+  var cachedHeaderFileName = this.cacheDirectory + key + ".json";
+  headersReader = fs.createReadStream(cachedHeaderFileName);
 
   //If the file doesn't exist, then make the actual request
   headersReader.on("error", function (error) {
     if (error.code != "ENOENT") self.handleError(error);
-    makeRequest();
+    return makeRequest();
   });
 
   headersReader.on("open", function (fd) {
@@ -256,7 +257,7 @@ CachedRequest.prototype.cachedRequest = function () {
   });
 
   //Makes the actual request and caches the response
-  function makeRequest () {
+  function makeRequest() {
     request = self.request.apply(null, args);
     requestMiddleware.use(request);
     request.on("response", function (response) {
@@ -267,7 +268,12 @@ CachedRequest.prototype.cachedRequest = function () {
         response.on('error', function (error) {
           self.handleError(error);
         });
-        fs.writeFile(self.cacheDirectory + key + ".json", JSON.stringify(response.headers), function (error) {
+        var timestamp = Date.now();
+        var tmpHeaderName = cachedHeaderFileName + timestamp;
+
+        // Presence of the header means the cache entry is ready.  Save it to a temporary location
+        // until the caching process is complete.
+        fs.writeFile(tmpHeaderName, JSON.stringify(response.headers), function (error) {
           if (error) self.handleError(error);
         });
 
@@ -280,11 +286,12 @@ CachedRequest.prototype.cachedRequest = function () {
         contentEncoding = response.headers['content-encoding'] || '';
         contentEncoding = contentEncoding.trim().toLowerCase();
 
+        var stream;
         if (contentEncoding === 'gzip') {
           response.on('error', function (error) {
             responseWriter.end();
           });
-          response.pipe(responseWriter);
+          stream = response.pipe(responseWriter);
         } else {
           gzipper = zlib.createGzip();
           response.on('error', function (error) {
@@ -298,8 +305,16 @@ CachedRequest.prototype.cachedRequest = function () {
             response.unpipe(gzipper);
             gzipper.end();
           });
-          response.pipe(gzipper).pipe(responseWriter);
+          stream = response.pipe(gzipper).pipe(responseWriter);
         }
+
+        // once the stream is complete, we know the data file was written succesfully
+        // after that, it's ok to rename the header file so future requests can use it.
+        stream.on('finish', function(){
+          fs.rename(tmpHeaderName, cachedHeaderFileName, function(err) {
+            if (err) self.handleError(err);
+          })
+        });;
       }
     });
     self.emit("request", args[0]);

--- a/lib/request-middleware.js
+++ b/lib/request-middleware.js
@@ -56,10 +56,22 @@ RequestMiddleware.prototype.use = function (request) {
       self.emit("response", response);
     };
     response.on("data", function (data) {
-      self.push(data);
+      try {
+        self.push(data);
+      } catch (e) {
+        // trying to avoid crashing the whole process
+        console.log("Caught request in request caching library (response.data): " + e);
+        self.emit("error", e);
+      }
     });
     response.on("end", function () {
-      self.push(null);
+      try {
+        self.push(null);
+      } catch (e) {
+        // trying to avoid crashing the whole process
+        console.log("Caught request in request caching library (response.end): " + e);
+        self.emit("error", e);
+      }
     });
   });
 


### PR DESCRIPTION
This update writes the header file to a temporary location and only moves it to the final location once writing the cached data file is complete.  Requests with the same cache key should not see the cache entry until both files are successfully written and flushed.