### PR TITLE
Add missing license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "Node.js module to perform HTTP requests with caching support",
   "author": "Daniel López <danypype@gmail.com>",
+  "license": "MIT",
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
Update package.json to communicate the license of this package, as described in project's [LICENSE file](https://github.com/alltherooms/cached-request/blob/f5910be78bafa026e1ba2ff6e56f097f41534913/LICENSE).