### PR TITLE
Parse the body consistently whether cached or not [#22]

### DIFF
--- a/lib/cached-request.js
+++ b/lib/cached-request.js
@@ -116,7 +116,6 @@ CachedRequest.prototype.cachedRequest = function (...args) {
   const requestMiddleware = new RequestMiddleware();
   const options = args[0];
   const ttl = options.ttl || this.ttl;
-  let mustParseJSON = false;
 
   if (typeof options != "object") {
     throw new Error("An options object must provided. e.g: request(options)")
@@ -125,10 +124,6 @@ CachedRequest.prototype.cachedRequest = function (...args) {
   let callback;
   if (typeof args[args.length - 1] == "function") {
     callback = args[args.length - 1];
-  };
-
-  if (options.json) {
-    mustParseJSON = true;
   };
 
   let key = JSON.stringify(this.normalizeOptions(options));
@@ -166,7 +161,7 @@ CachedRequest.prototype.cachedRequest = function (...args) {
       }
 
       //Open the response file
-      const responseReader = fs.createReadStream(this.cacheDirectory + key);
+      const responseReader = fs.createReadStream(dataFilepath);
 
       //If it doesn't exist, then make the actual request
       responseReader.on("error", (error) => {
@@ -201,51 +196,32 @@ CachedRequest.prototype.cachedRequest = function (...args) {
           //Emit the "response" event to the client sending the fake response
           requestMiddleware.emit("response", response);
 
-          var stream;
-          if (response.headers['content-encoding'] === 'gzip') {
-            stream = responseReader;
-          } else {
-            // Gunzip the response file
-            stream = zlib.createGunzip();
-            responseReader.on('error', (error) => {
-              stream.end();
-            });
-            stream.on('error', (error) => {
-              responseReader.close();
-            });
-            responseReader.pipe(stream);
-          }
+          const stream = zlib.createGunzip();
+          responseReader.on('error', (error) => {
+            stream.end();
+          });
+          stream.on('error', (error) => {
+            responseReader.close();
+          });
+          responseReader.pipe(stream);
 
-          //Read the response file
-          var responseBody;
+          let bodyBuffer;
           stream.on("data", (data) => {
-            //Write to the response
-            response.write(data);
-            //If a callback was provided, then buffer the response to send it later
             if (callback) {
-              responseBody = responseBody ? Buffer.concat([responseBody, data]) : data;
+              bodyBuffer = bodyBuffer ? Buffer.concat([bodyBuffer, data]) : data;
             }
-            //Push data to the client's request
+            response.write(data);
             requestMiddleware.push(data);
           });
           stream.on("end", () => {
-            //End response
-            response.end();
-            //If a callback was provided
             if (callback) {
-              //Se the response.body
-              response.body = responseBody;
-              //Parse the response body (it needed)
-              if (mustParseJSON) {
-                try {
-                  responseBody = JSON.parse(responseBody.toString());
-                } catch (e) {
-                  return callback(e);
-                };
-              };
-              //callback with the response and body
-              callback(null, response, responseBody);
+              response.body = bodyBuffer;
+              this.processBody(bodyBuffer, options, (err, body) => {
+                if (err) return callback(err);
+                callback(null, response, body);
+              });
             };
+            response.end();
             requestMiddleware.push(null);
           });
         });
@@ -264,7 +240,6 @@ CachedRequest.prototype.makeRequest = function (options, ...args) {
   const request = this.request.apply(null, args);
   requestMiddleware.use(request);
   request.on("response", (response) => {
-    //Only cache successful responses
     if (response.statusCode >= 200 && response.statusCode < 300) {
       response.on('error', (error) => {
         this.handleError(error);
@@ -278,30 +253,47 @@ CachedRequest.prototype.makeRequest = function (options, ...args) {
         this.handleError(error);
       });
 
-      const contentEncoding = (response.headers['content-encoding'] || '').trim().toLowerCase();
-      if (contentEncoding === 'gzip') {
-        response.on('error', (error) => {
-          responseWriter.end();
-        });
-        response.pipe(responseWriter);
-      } else {
-        const gzipper = zlib.createGzip();
-        response.on('error', (error) => {
-          gzipper.end();
-        });
-        gzipper.on('error', (error) => {
-          this.handleError(error);
-          responseWriter.end();
-        });
-        responseWriter.on('error', (error) => {
-          response.unpipe(gzipper);
-          gzipper.end();
-        });
-        response.pipe(gzipper).pipe(responseWriter);
-      }
+      // gzip all responses to make it easier when reading
+      // from the cache
+      const gzipper = zlib.createGzip();
+      response.on('error', (error) => {
+        gzipper.end();
+      });
+      gzipper.on('error', (error) => {
+        this.handleError(error);
+        responseWriter.end();
+      });
+      responseWriter.on('error', (error) => {
+        response.unpipe(gzipper);
+        gzipper.end();
+      });
+      response.pipe(gzipper).pipe(responseWriter);
     }
   });
   this.emit("request", args[0]);
+};
+
+CachedRequest.prototype.processBody = function (bodyBuffer, options, callback) {
+  const { encoding, gzip, json } = options;
+  if (encoding === null) return callback(null, bodyBuffer);
+  if (gzip === true) return this.gunzip(bodyBuffer, encoding, callback);
+  if (json === true) return this.jsonParse(bodyBuffer.toString(encoding), callback);
+  return callback(null, bodyBuffer.toString());
+};
+
+CachedRequest.prototype.gunzip = function (buffer, encoding, callback) {
+  zlib.gunzip(buffer, (err, result) => {
+    if (err) return callback(err);
+    callback(null, result.toString(encoding));
+  });
+}
+
+CachedRequest.prototype.jsonParse = function (json, callback) {
+  try {
+    return callback(null, JSON.parse(json));
+  } catch (e) {
+    return callback(e);
+  }
 };
 
 module.exports = CachedRequest;


### PR DESCRIPTION
This change set fixes #22.

Basically, the cachedRequest handler gzips all responses and parses the cached body according to request/request options (gzip, encoding, json).